### PR TITLE
Update user authentication and inactive user monitoring

### DIFF
--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/healthInformationSystem/SystemConfigsController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/healthInformationSystem/SystemConfigsController.groovy
@@ -2,12 +2,11 @@ package mz.org.fgh.sifmoz.backend.healthInformationSystem
 
 import grails.converters.JSON
 import grails.validation.ValidationException
-import mz.org.fgh.sifmoz.backend.clinic.Clinic
 import mz.org.fgh.sifmoz.backend.clinicSector.ClinicSector
 import mz.org.fgh.sifmoz.backend.clinicSectorType.ClinicSectorType
 
 import mz.org.fgh.sifmoz.backend.clinic.Clinic
-import mz.org.fgh.sifmoz.backend.packaging.Pack
+import mz.org.fgh.sifmoz.backend.protection.SecUser
 import mz.org.fgh.sifmoz.backend.service.ClinicalService
 import mz.org.fgh.sifmoz.backend.stockcenter.StockCenter
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
@@ -57,6 +56,9 @@ class SystemConfigsController {
 
         try {
             systemConfigsService.save(systemConfigs)
+            if(systemConfigs.key.equalsIgnoreCase("MAX_LOGIN_TRIES")){
+                updateUserMaxRetries(systemConfigs.value)
+            }
         } catch (ValidationException e) {
             respond systemConfigs.errors
             return
@@ -79,6 +81,9 @@ class SystemConfigsController {
 
         try {
             systemConfigsService.save(systemConfigs)
+            if(systemConfigs.key.equalsIgnoreCase("MAX_LOGIN_TRIES")){
+                updateUserMaxRetries(systemConfigs.value)
+            }
         } catch (ValidationException e) {
             respond systemConfigs.errors
             return
@@ -164,5 +169,18 @@ class SystemConfigsController {
         ClinicSector clinicSector = ClinicSector.get("8a8a823b81900fee0181902674b20004")
         clinicalService.clinicSectors = new HashSet<>(Arrays.asList(clinicSector))
         clinicalService.save(flush: true, failOnError: true)
+    }
+
+    void updateUserMaxRetries(String value){
+
+        SecUser.withTransaction {
+
+            for (def user in SecUser.list()){
+                user.loginRetries = Integer.parseInt(value)
+                user.save()
+            }
+
+        }
+
     }
 }

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/protection/SecUser.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/protection/SecUser.groovy
@@ -28,7 +28,8 @@ class SecUser implements Serializable, IRoleMenu {
     boolean accountLocked
     boolean passwordExpired
     String[] roles
-    int loginRetries = 3
+    int loginRetries
+    Date lastLogin = new Date()
 
     static transients = ['roles']
 
@@ -56,15 +57,15 @@ class SecUser implements Serializable, IRoleMenu {
         contact nullable: true, blank: true
         roles bindable: true
         clinicSectors bindable: true
-        loginRetries range: 0..3
+        loginRetries nullable: false
+        lastLogin nullable: false
+
     }
 
     static mapping = {
 	    password column: '`password`'
         clinics  joinTable: [name: "clinic_users", key: "sec_user_id", column: "clinic_id"]
-//        clinicSectors  joinTable: [name: "clinic_sector_users", key: "sec_user_id", column: "clinic_sector_id"]
-     //   id generator: "assigned"
-id column: 'id', index: 'Pk_SecUser_Idx'
+        id column: 'id', index: 'Pk_SecUser_Idx'
     }
 
     @Override

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/reports/pharmacyManagement/historicoLevantamento/HistoricoLevantamentoReport.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/reports/pharmacyManagement/historicoLevantamento/HistoricoLevantamentoReport.groovy
@@ -31,12 +31,13 @@ class HistoricoLevantamentoReport extends BaseEntity {
     String clinic
     String patientType
     String clinicsector
+    String idmeduser
 
     public HistoricoLevantamentoReport(){
 
     }
 
-    HistoricoLevantamentoReport(String nid, String firstNames, String middleNames, String lastNames, String cellphone, String tipoTarv, String startReason, String therapeuticalRegimen, String dispenseType, String dispenseMode, String clinicalService,String clinicsector) {
+    HistoricoLevantamentoReport(String nid, String firstNames, String middleNames, String lastNames, String cellphone, String tipoTarv, String startReason, String therapeuticalRegimen, String dispenseType, String dispenseMode, String clinicalService, String clinicsector, String idmeduser) {
         this.nid = nid
         this.firstNames = firstNames
         this.middleNames = middleNames
@@ -49,6 +50,7 @@ class HistoricoLevantamentoReport extends BaseEntity {
         this.dispenseMode = dispenseMode
         this.clinicalService = clinicalService
         this.clinicsector = clinicsector
+        this.idmeduser = idmeduser
     }
     static constraints = {
         id generator: "uuid"
@@ -57,6 +59,7 @@ class HistoricoLevantamentoReport extends BaseEntity {
         endDate nullable: true
         startReason nullable: true
         patientType nullable: true
+        idmeduser nullable: true
     }
 
 

--- a/grails-app/init/mz/org/fgh/sifmoz/backend/BootStrap.groovy
+++ b/grails-app/init/mz/org/fgh/sifmoz/backend/BootStrap.groovy
@@ -820,25 +820,7 @@ class BootStrap {
     List<Object> listUsers() {
         List<Object> usersList = new ArrayList<>()
         usersList.add(new LinkedHashMap(username: 'admin', password: 'admin', fullName: 'admin', contact: 'admin', email: 'admin@gmail.com', openmrsPassword: Utilities.getMd5('admin')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.FHI', password: 'Fhi761', fullName: 'IDMED.FHI', contact: 'IDMED.FHI', email: 'IDMED.FHI@gmail.com', openmrsPassword: Utilities.getMd5('Fhi761')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.EPIC', password: 'Epic007', fullName: 'IDMED.EPIC', contact: 'IDMED.EPIC', email: 'IDMED.EPIC@gmail.com', openmrsPassword: Utilities.getMd5('Epic007')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.I-TECH', password: 'I-tech881', fullName: 'IDMED.I-TECH', contact: 'IDMED.I-TECH', email: 'IDMED.I-TECH@gmail.com', openmrsPassword: Utilities.getMd5('I-tech881')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.ICAP', password: 'Icap123', fullName: 'IDMED.ICAP', contact: 'IDMED.ICAP', email: 'IDMED.ICAP@gmail.com', openmrsPassword: Utilities.getMd5('Icap123')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.CCS', password: 'Ccs452', fullName: 'IDMED.CCS', contact: 'IDMED.CCS', email: 'IDMED.CCS@gmail.com', openmrsPassword: Utilities.getMd5('Ccs452')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.ARIEL', password: 'Ariel872', fullName: 'IDMED.ARIEL', contact: 'IDMED.ARIEL', email: 'IDMED.ARIEL@gmail.com', openmrsPassword: Utilities.getMd5('Ariel872')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.ECHO', password: 'Echo827', fullName: 'IDMED.ECHO', contact: 'IDMED.ECHO', email: 'IDMED.ECHO@gmail.com', openmrsPassword: Utilities.getMd5('Echo827')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.EGPAF', password: 'Egpaf897', fullName: 'IDMED.EGPAF', contact: 'IDMED.EGPAF', email: 'IDMED.EGPAF@gmail.com', openmrsPassword: Utilities.getMd5('Egpaf897')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.JHPIEGO', password: 'Jhpiego562', fullName: 'IDMED.JHPIEGO', contact: 'IDMED.JHPIEGO', email: 'IDMED.JHPIEGO@gmail.com', openmrsPassword: Utilities.getMd5('Jhpiego562')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.FGH', password: 'Fgh542', fullName: 'IDMED.FGH', contact: 'IDMED.FGH', email: 'IDMED.FGH@gmail.com', openmrsPassword: Utilities.getMd5('Fgh542')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.USAID', password: 'Usaid098', fullName: 'IDMED.USAID', contact: 'IDMED.USAID', email: 'IDMED.USAID@gmail.com', openmrsPassword: Utilities.getMd5('Usaid098')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.CDC', password: 'Cdc622', fullName: 'IDMED.CDC', contact: 'IDMED.CDC', email: 'IDMED.CDC@gmail.com', openmrsPassword: Utilities.getMd5('Cdc622')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.CMAM', password: 'Cmam252', fullName: 'IDMED.CMAM', contact: 'IDMED.CMAM', email: 'IDMED.CMAM@gmail.com', openmrsPassword: Utilities.getMd5('Cmam252')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.PHIV', password: 'Phiv545', fullName: 'IDMED.PHIV', contact: 'IDMED.PHIV', email: 'IDMED.PHIV@gmail.com', openmrsPassword: Utilities.getMd5('Phiv545')))
         usersList.add(new LinkedHashMap(username: 'iDMED', password: 'iDMED123', fullName: 'iDMED', contact: 'iDMED', email: 'iDMED@gmail.com', openmrsPassword: Utilities.getMd5('iDMED123')))
-        usersList.add(new LinkedHashMap(username: 'IDMED.JEMBI', password: 'Jembi123', fullName: 'IDMED.JEMBI', contact: 'IDMED.JEMBI', email: 'IDMED.JEMBI@gmail.com', openmrsPassword: Utilities.getMd5('Jembi123')))
-        usersList.add(new LinkedHashMap(username: 'domingos.bernardo', password: 'dBernardo1', fullName: 'domingos.bernardo', contact: 'domingos.bernardo', email: 'domingos.bernardo@gmail.com', openmrsPassword: Utilities.getMd5('dBernardo1')))
-        usersList.add(new LinkedHashMap(username: 'user.sync', password: 'user.sync', fullName: 'Usuario Sincronizacao', contact: 'USER.SYNC', email: 'user.sync@gmail.com', openmrsPassword: Utilities.getMd5('userSync')))
-        usersList.add(new LinkedHashMap(username: 'pepfar', password: 'Pepfar123', fullName: 'Usuario Pepfar', contact: '', email: 'user.pepfar@gmail.com', openmrsPassword: Utilities.getMd5('Pepfar123')))
 
         return usersList
     }
@@ -883,6 +865,8 @@ class BootStrap {
         systemConfigsList.add(new LinkedHashMap(id: '570911CB-6D46-4A3A-8A56-906A73DF1062', value: 'ON', key: 'PARAMS_MIGRATION_ENGINE', description: 'Params migration engine'))
         // systemConfigsList.add(new LinkedHashMap(id: 'E6CDDA47-DC11-4DAA-8672-04B37DEE9703', value: 'LOCAL', key: 'INSTALATION_TYPE',  description: 'Local/Provincial Instalation'))
         systemConfigsList.add(new LinkedHashMap(id: 'B5C44B42-3328-40D9-90D7-6DFF90A672D4', value: 'true', key: 'ACTIVATE_DATA_MIGRATION', description: 'Indica se a migração de dados está activa ou não'))
+        systemConfigsList.add(new LinkedHashMap(id: '550e8400-e29b-41d4-a716-446655440000', value: '3', key: 'MAX_LOGIN_TRIES', description: 'Número máximo de tentativas para Login'))
+        systemConfigsList.add(new LinkedHashMap(id: '3b241101-e2bb-4255-8caf-4136c566a964', value: '90', key: 'MAX_ACTIVE_DAYS_WITHOUT_LOGIN', description: 'Número máximo de dias em activo sem login'))
 
         return systemConfigsList
     }

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/packaging/PackService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/packaging/PackService.groovy
@@ -2513,7 +2513,8 @@ abstract class PackService implements IPackService {
                 ep.episode_date,
                 prc.patient_status,
                 ssr.code,
-                cr.code as clinicsector
+                cr.code as clinicsector,
+                pack2.provider_uuid
                 from 
                 (
                 select distinct pat.id,
@@ -2636,7 +2637,8 @@ abstract class PackService implements IPackService {
                 ep.episode_date,
                 prc.patient_status,
                 ssr.code,
-                cr.code as clinicsector
+                cr.code as clinicsector,
+                pack2.provider_uuid
                 from 
                 (
                 select distinct pat.id,

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/protection/SecUserService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/protection/SecUserService.groovy
@@ -2,17 +2,59 @@ package mz.org.fgh.sifmoz.backend.protection
 
 import grails.gorm.services.Service
 import grails.gorm.transactions.Transactional
-import mz.org.fgh.sifmoz.backend.patientVisitDetails.IPatientVisitDetailsService
-import mz.org.fgh.sifmoz.backend.prescription.IPrescriptionService
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.prescription.Prescription
+import org.springframework.scheduling.annotation.Scheduled
 
 @Transactional
 @Service(Prescription)
-abstract class SecUserService implements ISecUserService{
+abstract class SecUserService implements ISecUserService {
 
     ISecUserService secUserService
 
-    SecUser saveSecUserAndRoles (SecUser secUser,List<Role> roles) {
+    private static final int DEFAULT_FALLBACK_EXPIRE_DAYS = 90
+
+    @Scheduled(cron = "0 0 12 * * 1,5")
+    void schedulerUserMonitoringRunning() {
+        SecUser.withTransaction {
+            suspendInactiveUserAccounts();
+        }
+    }
+
+    void suspendInactiveUserAccounts() {
+        List<SecUser> secUserList = findAllUsersWithLastLoginBefore(getExpireDate());
+        for (SecUser user : secUserList) {
+            expireAndLockAccount(user)
+        }
+    }
+
+    Date getExpireDate() {
+        SystemConfigs systemConfigs = SystemConfigs.findWhere(key: "MAX_ACTIVE_DAYS_WITHOUT_LOGIN");
+        def today = new Date();
+        if (systemConfigs) {
+            return today - Integer.parseInt(systemConfigs.value)
+        } else {
+            return today - DEFAULT_FALLBACK_EXPIRE_DAYS
+        }
+    }
+
+    List<SecUser> findAllUsersWithLastLoginBefore(Date expireDate) {
+        return SecUser.findAllByLastLoginLessThanEquals(expireDate)
+    }
+
+    void expireAndLockAccount(SecUser user) {
+        try {
+            user.accountLocked = true
+            user.accountExpired = true
+            user.passwordExpired = true
+            user.enabled = false
+            user.save()
+        } catch (Exception e) {
+            e.printStackTrace()
+        }
+    }
+
+    SecUser saveSecUserAndRoles(SecUser secUser, List<Role> roles) {
         if (secUser.hasErrors()) {
             transactionStatus.setRollbackOnly()
             respond secUser.errors
@@ -20,7 +62,7 @@ abstract class SecUserService implements ISecUserService{
         }
 
         secUserService.save(secUser)
-        for(Role role :roles)  {
+        for (Role role : roles) {
             SecUserRole.create secUser, role
         }
 

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/reports/pharmacyManagement/historicoLevantamento/HistoricoLevantamentoReportService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/reports/pharmacyManagement/historicoLevantamento/HistoricoLevantamentoReportService.groovy
@@ -136,6 +136,7 @@ abstract class HistoricoLevantamentoReportService implements IHistoricoLevantame
         item[8] == null? historicoLevantamentoReport.setDispenseType("") : historicoLevantamentoReport.setDispenseType(item[8].toString())
         item[9] == null? historicoLevantamentoReport.setDispenseMode("") : historicoLevantamentoReport.setDispenseMode(item[9].toString())
         item[15] == null? historicoLevantamentoReport.setClinicsector("") : historicoLevantamentoReport.setClinicsector(item[15].toString())
+        item[16] == null? historicoLevantamentoReport.setIdmeduser("") : historicoLevantamentoReport.setIdmeduser(extractUserName(item[16].toString()))
 
 
         // set pickUpDate
@@ -149,5 +150,25 @@ abstract class HistoricoLevantamentoReportService implements IHistoricoLevantame
             historicoLevantamentoReport.setNexPickUpDate(nextPickUpDate)
         }
         save(historicoLevantamentoReport)
+    }// Groovy
+
+
+    String extractUserName(String encodedString) {
+        String decodedStringBase64 = ""
+
+        try {
+            byte[] decodedBytes = Base64.decoder.decode(encodedString)
+            String decodedStr = new String(decodedBytes)
+            int stopIndex = decodedStr.indexOf(":")
+
+            if (stopIndex != -1) {
+                decodedStringBase64 = decodedStr.substring(0, stopIndex)
+            }
+        } catch (Exception e) {
+            log.error("Error decoding string: ", e)
+        }
+
+        return decodedStringBase64
     }
+
 }


### PR DESCRIPTION
The code includes several important enhancements related to user authentication and inactivity monitoring. The maximum number of login retry attempts is made configurable, with the value stored in system configurations. Moreover, user accounts will be locked and marked as expired if there are no logins within a certain number of days defined in system configurations. This commit also includes extracting provider_uuid and adding a field for the UUID in the packing service, and modifying reporting services to include the UUID.