### PR TITLE
Refactor pharmacy management SQL query to use groovy triple-quote multiline string

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -103,7 +103,7 @@ environments:
   development:
     dataSource:
       dbCreate: update
-      url: jdbc:postgresql://localhost:2345/chabeco
+      url: jdbc:postgresql://localhost:2345/gurue
   test:
     dataSource:
       dbCreate: update


### PR DESCRIPTION
The SQL query used in the pharmacy management report service has been refactored for improved readability and maintainability. The query has been moved into a groovy triple-quote multiline string which simplifies line breaks and string concatenation. Adjustments were also made to ceil values and expiry date checks within the SQL query.