### PR TITLE
Update Inventory model with cascade delete rule

### DIFF
--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/stockinventory/Inventory.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/stockinventory/Inventory.groovy
@@ -21,6 +21,7 @@ class Inventory extends BaseEntity {
     static mapping = {
         id generator: "assigned"
         id column: 'id', index: 'Pk_Inventory_Idx'
+        adjustments cascade: 'all-delete-orphan'
     }
 
     static constraints = {


### PR DESCRIPTION
An 'all-delete-orphan' cascade rule has been added to the 'adjustments' in the Inventory domain model. This rule ensures that, when an Inventory instance gets deleted, all associated Adjustment instances are also removed from the database.