### PR TITLE
Fix typo in schedulerUserMonitoringRunning method

### DIFF
--- a/grails-app/services/mz/org/fgh/sifmoz/backend/protection/SecUserService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/protection/SecUserService.groovy
@@ -19,7 +19,7 @@ class SecUserService {
 
     @Scheduled(cron = "0 0 12 * * 1,5")
     void schedulerUserMonitoringRunning() {
-        println('CRON FOR USERS UPDDATE - DATE '+ new Date())
+        println('CRON FOR USERS UPDATE - DATE '+ new Date())
         SecUser.withTransaction {
             suspendInactiveUserAccounts()
         }


### PR DESCRIPTION
The typo ("UPDDATE") in the println statement in schedulerUserMonitoringRunning method is corrected to "UPDATE". This change clarifies and maintains the professionalism of the logging message.