### PR TITLE
Assign main clinic and calculate matchId for new patient

### DIFF
--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/patient/PatientController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/patient/PatientController.groovy
@@ -53,11 +53,21 @@ class PatientController extends RestfulController {
     @Transactional
     def save() {
         Patient patient = new Patient()
+        Clinic clinic = Clinic.findByMainClinic(true)
         def objectJSON = request.JSON
         patient = objectJSON as Patient
         patient.identifiers = [].withDefault { new PatientServiceIdentifier() }
+        patient.clinic = clinic
         patient.beforeInsert()
 
+        if (patient.getMatchId() == null) {
+            def  patientAux =  Patient.findAll( [max: 2, sort: ['matchId': 'desc']])
+            if (patientAux.size() == 0) {
+                patient.setMatchId(1)
+            } else {
+                patient.setMatchId(patientAux.get(0).matchId + 1)
+            }
+        }
         patient.validate()
 
         if (objectJSON.id) {


### PR DESCRIPTION
In the save method of PatientController, two enhancements are introduced. Firstly, the main clinic is assigned to a patient while saving. Secondly, the matchId is calculated for the new patient record. If no such records exist yet, the matchId will be 1; otherwise, it will be incremented from the latest matchId.