### PR TITLE
Fixed gender case and null handling in RestOpenMRSClient

### DIFF
--- a/grails-app/utils/mz/org/fgh/sifmoz/backend/restUtils/RestOpenMRSClient.groovy
+++ b/grails-app/utils/mz/org/fgh/sifmoz/backend/restUtils/RestOpenMRSClient.groovy
@@ -386,7 +386,7 @@ class RestOpenMRSClient {
                 String openmrsJSON  =
                          "{\"person\":"
                                 .concat("{")
-                                .concat( "\"gender\": \"" + patient.gender + "\",")
+                                .concat( "\"gender\": \"" + patient?.gender?.toString()?.charAt(0)?.toUpperCase() + "\",")
                                 .concat( "\"names\":")
                                 .concat("[{\"givenName\": \"" + patient.firstNames + "\", \"middleName\": \"" + patient.middleNames + "\", \"familyName\": \"" + patient.lastNames + "\"}], \"birthdate\": \"" + dateOfBirthFormated+ "\"")
                                 .concat( "},")


### PR DESCRIPTION
The gender field in the JSON build process in RestOpenMRSClient now respects case settings and prevents potential crashes when encountering null gender data. It transforms the gender first character to uppercase and gracefully handles null values to ensure robustness.