### PR TITLE
Add operation_type to Inventory services and report

### DIFF
--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/reports/stock/InventoryReportTemp.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/reports/stock/InventoryReportTemp.groovy
@@ -34,6 +34,7 @@ class InventoryReportTemp extends BaseEntity {
     Long adjustedValue
     String formDescription
     String notes
+    String operation_type
 
 
 

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/reports/stock/InventoryReportService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/reports/stock/InventoryReportService.groovy
@@ -176,11 +176,12 @@ abstract class InventoryReportService implements IInventoryReportService {
         inventoryReportTemp.setBatchNumber(item[4])
         Date expireDate =formatter.parse(item[1].toString())
         inventoryReportTemp.setExpireDate(expireDate)
-        inventoryReportTemp.setBalance((long) Double.parseDouble(String.valueOf(item[7])) )
+        inventoryReportTemp.setBalance((long) Double.parseDouble(String.valueOf(item[7])))
         inventoryReportTemp.setAdjustedValue((long) Double.parseDouble(String.valueOf(item[6])))
         inventoryReportTemp.setFormDescription(item[8])
         inventoryReportTemp.setNotes(item[9])
         inventoryReportTemp.setInventoryId(item[10])
+        inventoryReportTemp.setOperation_type(item[11])
 
         try {
             save(inventoryReportTemp)

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/stockinventory/InventoryService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/stockinventory/InventoryService.groovy
@@ -103,9 +103,11 @@ abstract class InventoryService implements IInventoryService{
                 "s.stock_moviment, " +
                 "f.description as formDescription, " +
                 "sa.notes,"+
-                "i.id as inventoryId " +
+                "i.id as inventoryId, " +
+                "sot.code as operation_type " +
                 "from stock_adjustment sa \n" +
                 "inner join inventory i on (i.id = sa.inventory_id)\n" +
+                "inner join stock_operation_type sot on (sot.id = sa.operation_id)\n" +
                 "inner join stock s on s.id = sa.adjusted_stock_id \n" +
                 "inner join drug d on d.id = s.drug_id \n" +
                 "inner join form f on f.id = d.form_id \n" +


### PR DESCRIPTION
The commit adds a new field, operation_type, to the InventoryService and InventoryReportService. It makes changes to the queries in the services to fetch the operation_type and subsequently updates the InventoryReportTemp domain object to include this field. These changes allow for better inventory tracking.