### PR TITLE
Update ReportSearchParams and PregnancyScreening classes

### DIFF
--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/PregnancyScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/PregnancyScreening.groovy
@@ -25,12 +25,13 @@ class PregnancyScreening extends BaseEntity {
 
     static constraints = {
         lastMenstruation(nullable: true, blank: true)
-      //  clinic nullable: false
+        clinic blank: true, nullable: true
     }
 
     def beforeInsert() {
         if (!id) {
             id = UUID.randomUUID()
+            clinic = Clinic.findWhere(mainClinic: true)
         }
     }
 

--- a/grails-app/utils/mz/org/fgh/sifmoz/backend/multithread/ReportSearchParams.java
+++ b/grails-app/utils/mz/org/fgh/sifmoz/backend/multithread/ReportSearchParams.java
@@ -146,6 +146,7 @@ public class ReportSearchParams implements Validateable {
     }
 
     private void adjustEndDateIfAfterCurrentDate(Date currentDate) {
+        if(getReportType() != null)
         if (!getReportType().equalsIgnoreCase("EXPECTED_PATIENTS") && endDate.after(currentDate)) {
             setEndDate(currentDate);
         }


### PR DESCRIPTION
Adjusted the function `adjustEndDateIfAfterCurrentDate` in `ReportSearchParams.java` to check if ReportType is null before proceeding with any action. In `PregnancyScreening.groovy`, constraint for 'clinic' was changed to nullable and blank. Also, 'clinic' will now default to the main clinic during the beforeInsert method.