### PR TITLE
Replace direct ClinicalService references with IDs

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -89,6 +89,7 @@ grails:
       stampEnabled: true
 dataSource:
   driverClassName: org.postgresql.Driver
+  dialect: hibernate.MyPostgreSQLDialect
   username: postgres
   password: postgres
   pooled: true
@@ -102,7 +103,7 @@ environments:
   development:
     dataSource:
       dbCreate: update
-      url: jdbc:postgresql://localhost:9876/pescadores
+      url: jdbc:postgresql://localhost:9876/idmed
   test:
     dataSource:
       dbCreate: update

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/patientVisit/PatientVisitController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/patientVisit/PatientVisitController.groovy
@@ -190,8 +190,8 @@ class PatientVisitController extends RestfulController {
                     }
                     item.pack.packagedDrugs.each { packagedDrugs ->
                         def clinicalService = item.episode.patientServiceIdentifier.service
-                        if (!packagedDrugs.drug.clinicalService) {
-                            packagedDrugs.drug.clinicalService = clinicalService
+                        if (!packagedDrugs.drug.clinical_service_id) {
+                            packagedDrugs.drug.clinical_service_id = clinicalService.id
                         }
                     }
                     if(!syncStatus)

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/service/ClinicalServiceController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/service/ClinicalServiceController.groovy
@@ -86,8 +86,8 @@ class ClinicalServiceController extends RestfulController {
             return
         }
 
-        clinicalService.clinicSectors = [].withDefault {new ClinicSector()}
-      //  clinicalService.therapeuticRegimens = [].withDefault {new TherapeuticRegimen()}
+        clinicalService.clinicSectors = [].withDefault { new ClinicSector() }
+//        clinicalService.therapeuticRegimens = [].withDefault { new TherapeuticRegimen() }
         (objectJSON.clinicSectors as List).collect { item ->
             if (item) {
                 def clinicSectorObject = ClinicSector.get(item.id)
@@ -97,15 +97,16 @@ class ClinicalServiceController extends RestfulController {
                 clinicalService.addToClinicSectors(clinicSectorObject)
             }
         }
-/*
-        (objectJSON.therapeuticRegimens as List).collect { item ->
+
+/*        (objectJSON.therapeuticRegimens as List).collect { item ->
             if (item) {
-                def therapeuticRegimenObject = TherapeuticRegimen.findWhere(id: item.id)
-                if(therapeuticRegimenObject.active)
-                clinicalService.addToTherapeuticRegimens(therapeuticRegimenObject)
+                def therapeuticRegimenObject = TherapeuticRegimen.get(item.id)
+                if (therapeuticRegimenObject.active)
+                    clinicalService.addToTherapeuticRegimens(therapeuticRegimenObject)
             }
         }
 */
+
         try {
             clinicalService.save(flush: true, failOnError: true)
         } catch (ValidationException e) {
@@ -119,15 +120,15 @@ class ClinicalServiceController extends RestfulController {
         def clinicSectorJSON = JSONSerializer.setLightObjectListJsonResponse(clinicalService.clinicSectors as List)
         def therapeuticRegimensJSON = JSONSerializer.setLightObjectListJsonResponse(clinicalService.therapeuticRegimens as List)
 
-            if(clinicSectorJSON.length() > 0){
+        if (clinicSectorJSON.length() > 0) {
             result.put('clinicSectors', clinicSectorJSON)
-        }else{
+        } else {
             result.remove('clinicSectors')
         }
 
-        if(therapeuticRegimensJSON.length() > 0){
+        if (therapeuticRegimensJSON.length() > 0) {
             result.put('therapeuticRegimens', therapeuticRegimensJSON)
-        }else{
+        } else {
             result.remove('therapeuticRegimens')
         }
 
@@ -145,7 +146,7 @@ class ClinicalServiceController extends RestfulController {
         render status: NO_CONTENT
     }
 
-    def clinicSectorSaved(ClinicSector clinicSector){
+    def clinicSectorSaved(ClinicSector clinicSector) {
         ClinicSector.withTransaction {
             return clinicSector.save(flush: true)
         }

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/drug/Drug.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/drug/Drug.groovy
@@ -21,7 +21,8 @@ class Drug extends BaseEntity {
     String defaultPeriodTreatment
     String fnmCode
     String uuidOpenmrs
-    ClinicalService clinicalService
+    String clinical_service_id
+//    ClinicalService clinicalService
     Form form
     static belongsTo = [TherapeuticRegimen]
     boolean active
@@ -41,7 +42,7 @@ class Drug extends BaseEntity {
         fnmCode nullable: false, unique: true
         packSize(min: 0)
         uuidOpenmrs nullable: true
-        clinicalService nullable: false
+        clinical_service_id nullable: true
         defaultTimes(min:1)
     }
 

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/service/ClinicalService.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/service/ClinicalService.groovy
@@ -10,6 +10,11 @@ import mz.org.fgh.sifmoz.backend.serviceattributetype.ClinicalServiceAttributeTy
 import mz.org.fgh.sifmoz.backend.therapeuticRegimen.TherapeuticRegimen
 
 class ClinicalService extends BaseEntity {
+    static final String PREP = "PREP"
+    static final String TARV = "TARV"
+    static final String PPE = "PPE"
+    static final String TPT = "TPT"
+    static final String CCR = "CCR"
 
     String id
     String code
@@ -17,9 +22,8 @@ class ClinicalService extends BaseEntity {
     IdentifierType identifierType
     boolean active
 
-    static belongsTo = [ClinicalServiceAttributeType]
+    static belongsTo = [ClinicalServiceAttributeType, TherapeuticRegimen]
     static hasMany = [clinicalServiceAttributes: ClinicalServiceAttributeType, therapeuticRegimens: TherapeuticRegimen, clinicSectors: ClinicSector]
-
     static mapping = {
         id generator: "assigned"
         id column: 'id', index: 'Pk_ClinicalService_Idx'
@@ -36,20 +40,32 @@ class ClinicalService extends BaseEntity {
         description nullable: false
     }
 
-    boolean isPrep() {
-        return this.code == "PREP"
-    }
-
-    boolean isTarv() {
-        return this.code == "TARV"
-    }
-
     @Override
     List<Menu> hasMenus() {
         List<Menu> menus = new ArrayList<>()
         Menu.withTransaction {
-            menus = Menu.findAllByCodeInList(Arrays.asList(patientMenuCode,groupsMenuCode,dashboardMenuCode,administrationMenuCode,reportsMenuCode,homeMenuCode))
+            menus = Menu.findAllByCodeInList(Arrays.asList(patientMenuCode, groupsMenuCode, dashboardMenuCode, administrationMenuCode, reportsMenuCode, homeMenuCode))
         }
         return menus
+    }
+
+    boolean isPREP() {
+        return this.code.equalsIgnoreCase(PREP)
+    }
+
+    boolean isTARV() {
+        return this.code.equalsIgnoreCase(TARV)
+    }
+
+    boolean isPPE() {
+        return this.code.equalsIgnoreCase(PPE)
+    }
+
+    boolean isTPT() {
+        return this.code.equalsIgnoreCase(TPT)
+    }
+
+    boolean isCCR() {
+        return this.code.equalsIgnoreCase(CCR)
     }
 }

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/therapeuticRegimen/TherapeuticRegimen.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/therapeuticRegimen/TherapeuticRegimen.groovy
@@ -16,8 +16,7 @@ class TherapeuticRegimen extends BaseEntity {
     String code
     String description
     String openmrsUuid
-    static belongsTo = [clinicalService: ClinicalService]
-    static hasMany = [drugs: Drug]
+    static hasMany = [drugs: Drug, clinicalServices: ClinicalService]
 
     static mapping = {
         id generator: "assigned"
@@ -46,27 +45,27 @@ class TherapeuticRegimen extends BaseEntity {
         return menus
     }
 
-    boolean isTARV(){
-        return this.clinicalService?.code?.contains("TARV")
-    }
-
-    boolean isTPT(){
-        return  this.clinicalService?.code?.contains("TPT")
-    }
-
-    boolean isPreP(){
-        return this.clinicalService?.code?.contains("PREP")
-    }
-
-    boolean isTB() {
-        return this.clinicalService?.code?.contains("TB")
-    }
-
-    boolean isPPE() {
-        return this.clinicalService?.code?.contains("PPE")
-    }
-
-    boolean isMALARIA() {
-        return this.clinicalService?.code?.contains("MALARIA")
-    }
+//    boolean isTARV(){
+//        return this.clinicalService?.code?.contains("TARV")
+//    }
+//
+//    boolean isTPT(){
+//        return  this.clinicalService?.code?.contains("TPT")
+//    }
+//
+//    boolean isPreP(){
+//        return this.clinicalService?.code?.contains("PREP")
+//    }
+//
+//    boolean isTB() {
+//        return this.clinicalService?.code?.contains("TB")
+//    }
+//
+//    boolean isPPE() {
+//        return this.clinicalService?.code?.contains("PPE")
+//    }
+//
+//    boolean isMALARIA() {
+//        return this.clinicalService?.code?.contains("MALARIA")
+//    }
 }

--- a/grails-app/init/mz/org/fgh/sifmoz/backend/BootStrap.groovy
+++ b/grails-app/init/mz/org/fgh/sifmoz/backend/BootStrap.groovy
@@ -568,6 +568,7 @@ class BootStrap {
     void initTherapeuticRegimen() {
         for (therapeuticRegimenObject in listTherapeuticRegimen()) {
 
+           ClinicalService clinicalService =  ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
             TherapeuticRegimen therapeuticRegimen1 = TherapeuticRegimen.findById(therapeuticRegimenObject.id.toString().trim())
             TherapeuticRegimen therapeuticRegimen2 = TherapeuticRegimen.findByCode(therapeuticRegimenObject.code)
 
@@ -580,8 +581,9 @@ class BootStrap {
                     therapeuticRegimen.active = therapeuticRegimenObject.active
                     therapeuticRegimen.description = therapeuticRegimenObject.description
                     therapeuticRegimen.openmrsUuid = therapeuticRegimenObject.openmrs_uuid
-                    therapeuticRegimen.clinicalService = ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
+                //    therapeuticRegimen.clinicalService = ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
                     therapeuticRegimen.save(flush: true, failOnError: true)
+                    clinicalService.addToTherapeuticRegimens(therapeuticRegimen)
                 } else {
                     if (therapeuticRegimen2.code.equalsIgnoreCase("X6APed")) {
                         therapeuticRegimen2.regimenScheme = "ABC+3TC+DTG (2DFC+DTG50)"
@@ -591,6 +593,7 @@ class BootStrap {
                     therapeuticRegimen2.openmrsUuid = therapeuticRegimenObject.openmrs_uuid
                     therapeuticRegimen2.clinicalService = ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
                     therapeuticRegimen2.save(flush: true, failOnError: true)
+                    clinicalService.addToTherapeuticRegimens(therapeuticRegimen2)
                 }
             } else {
                 if (therapeuticRegimen1.code.equalsIgnoreCase("X6APed")) {
@@ -599,9 +602,11 @@ class BootStrap {
                 }
 //                therapeuticRegimen1.active = therapeuticRegimenObject.active
                 therapeuticRegimen1.openmrsUuid = therapeuticRegimenObject.openmrs_uuid
-                therapeuticRegimen1.clinicalService = ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
+//                therapeuticRegimen1.clinicalService = ClinicalService.findById(therapeuticRegimenObject.clinical_service_id)
                 therapeuticRegimen1.save(flush: true, failOnError: true)
+                clinicalService.addToTherapeuticRegimens(therapeuticRegimen1)
             }
+            clinicalService.save()
         }
     }
 
@@ -620,13 +625,15 @@ class BootStrap {
                 drug.fnmCode = drugObject.fnm_code
                 drug.uuidOpenmrs = drugObject.uuid_openmrs
                 drug.active = drugObject.active
-                drug.clinicalService = ClinicalService.findById(drugObject.clinical_service_id)
+                drug.clinical_service_id = drugObject.clinical_service_id
+//                drug.clinicalService = ClinicalService.findById(drugObject.clinical_service_id)
                 drug.form = Form.findById(drugObject.form_id)
                 drug.save(flush: true, failOnError: true)
 
             } else {
-                if (drug1.getClinicalService() == null) {
-                    drug1.clinicalService = ClinicalService.findById(drugObject.clinical_service_id)
+                if (drug1.getClinical_service_id() == null) {
+                    drug1.clinical_service_id = drugObject.clinical_service_id
+//                    drug1.clinicalService = ClinicalService.findById(drugObject.clinical_service_id)
                     drug1.save(flush: true, failOnError: true)
                 } else {
                     if (drug1.getUuidOpenmrs() == null || drug1.getUuidOpenmrs().trim().empty) {

--- a/grails-app/services/mz/org/fgh/sifmoz/backend/drug/DrugRestService.groovy
+++ b/grails-app/services/mz/org/fgh/sifmoz/backend/drug/DrugRestService.groovy
@@ -83,7 +83,8 @@ class DrugRestService extends SynchronizerTask {
                                 drugExist.defaultPeriodTreatment = drugObject.getAt(("defaultPeriodTreatment"))
                                 drugExist.fnmCode = drugObject.getAt(("fnmCode"))
                                 drugExist.uuidOpenmrs = drugObject.getAt(("uuidOpenmrs"))
-                                drugExist.clinicalService = ClinicalService.get(drugObject.getAt("clinicalService").getAt("id") as String)
+                                drugExist.clinical_service_id = drugObject.getAt("clinicalService").getAt("id")
+//                                drugExist.clinicalService = ClinicalService.get(drugObject.getAt("clinicalService").getAt("id") as String)
                                 drugExist.form = Form.get(drugObject.getAt("form").getAt("id") as String)
                                 drugExist.active = drugObject.getAt(("active"))
                                 drugExist.save()
@@ -132,7 +133,7 @@ class DrugRestService extends SynchronizerTask {
                                                 regimeExist.code = regimeTerapeutico.getAt("code")
                                                 regimeExist.description = regimeTerapeutico.getAt("description")
                                                 regimeExist.openmrsUuid =  regimeTerapeutico.getAt("uuidOpenmrs")
-                                                regimeExist.clinicalService = regimeTerapeutico.getAt("areaCode").equals("TB") ? ClinicalService.findWhere(code: "TB") : ClinicalService.findWhere(code: "TARV")
+//                                                regimeExist.clinicalService = regimeTerapeutico.getAt("areaCode").equals("TB") ? ClinicalService.findWhere(code: "TB") : ClinicalService.findWhere(code: "TARV")
                                                 regimeExist.beforeInsert()
                                             }
                                             regimeExist.addToDrugs(drugExist)
@@ -167,7 +168,8 @@ class DrugRestService extends SynchronizerTask {
             drugExist.defaultPeriodTreatment = regimeTerapeutico.getAt("areaCode").equals("TB") ? "": "Dia"
             drugExist.fnmCode = drugObject.getAt("fnm")
             drugExist.uuidOpenmrs = drugObject.getAt("uuidOpenmrs")
-            drugExist.clinicalService = regimeTerapeutico.getAt("areaCode").equals("TB") ? ClinicalService.findWhere(code: "TB") : ClinicalService.findWhere(code: "TARV")
+            drugExist.clinical_service_id = regimeTerapeutico.getAt("areaCode").equals("TB") ? ClinicalService.findWhere(code: "TB").id : ClinicalService.findWhere(code: "TARV").id
+//            drugExist.clinicalService = regimeTerapeutico.getAt("areaCode").equals("TB") ? ClinicalService.findWhere(code: "TB") : ClinicalService.findWhere(code: "TARV")
             drugExist.form = findOrSave(drugObject.getAt("pharmaceuticFormDescription") as String)
             drugExist.active = true
             drugExist.beforeInsert()

--- a/grails-app/utils/mz/org/fgh/sifmoz/backend/restUtils/RestOpenMRSClient.groovy
+++ b/grails-app/utils/mz/org/fgh/sifmoz/backend/restUtils/RestOpenMRSClient.groovy
@@ -43,26 +43,28 @@ class RestOpenMRSClient {
                 List<String> obsGroups = new ArrayList<>()
                 List<InteroperabilityAttribute> interoperabilityAttributes = Patient.get(patient.id).his.interoperabilityAttributes as List<InteroperabilityAttribute>
                 PatientVisitDetails pvd = PatientVisitDetails.findByPack(pack)
-                PrescriptionDetail prescriptionDetail = PrescriptionDetail.findByPrescription(Prescription.findById(pvd.prescription.id))
+                PatientServiceIdentifier identifier = PatientServiceIdentifier.findById(pvd?.episode?.patientServiceIdentifier?.id)
+                ClinicalService clinicalService = ClinicalService.findById(identifier?.service?.id)
+//                PrescriptionDetail prescriptionDetail = PrescriptionDetail.findByPrescription(Prescription.findById(pvd.prescription.id))
 
-                TherapeuticRegimen therapeuticRegimen = null
+//                TherapeuticRegimen therapeuticRegimen = null
 
-                if(prescriptionDetail.therapeuticRegimen){
-                    therapeuticRegimen = TherapeuticRegimen.findById(prescriptionDetail.therapeuticRegimen.id)
-                    if(therapeuticRegimen.isTARV() || therapeuticRegimen.isPPE()){
+                if(clinicalService){
+//                    therapeuticRegimen = TherapeuticRegimen.findById(prescriptionDetail.therapeuticRegimen.id)
+                    if(clinicalService.isTARV() || clinicalService.isPPE() || clinicalService.isCCR()){
                         inputAddPerson =  setOpenMRSFILA(interoperabilityAttributes, pack, patient, customizedDosage, obsGroupsJson, dispenseMod, packSize, obsGroups)
                     }
-                    if(therapeuticRegimen.isTPT())
+                    if(clinicalService.isTPT())
                         inputAddPerson =  setOpenMRSFILT(interoperabilityAttributes, pack, patient)
                 }else{
                     logger.error("Paciente "+ patient.firstNames +" "+ patient.lastNames+" com prescricao sem Regime Terapeutico")
-                    PrescriptionDetail.withNewTransaction {
-                        List<Drug> drugs = new ArrayList<Drug>()
-                        Drug drug = Drug.findById(pack.packagedDrugs.first().drug.id)
-                        therapeuticRegimen = drug.therapeuticRegimenList.first()
-                        prescriptionDetail.setTherapeuticRegimen(therapeuticRegimen)
-                        prescriptionDetail.save(flush: true, failOnError: true)
-                    }
+//                    PrescriptionDetail.withNewTransaction {
+//                        List<Drug> drugs = new ArrayList<Drug>()
+//                        Drug drug = Drug.findById(pack.packagedDrugs.first().drug.id)
+//                        therapeuticRegimen = drug.therapeuticRegimenList.first()
+//                        prescriptionDetail.setTherapeuticRegimen(therapeuticRegimen)
+//                        prescriptionDetail.save(flush: true, failOnError: true)
+//                    }
                 }
             } catch (Exception e) {
                 e.printStackTrace()


### PR DESCRIPTION
Refactor code to use clinical_service_id instead of direct ClinicalService object references. This simplifies saving entities and improves modularity. Some unused lines of code were also commented out for future removal.