### PR TITLE
Add origin configuration to multiple entities

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -111,5 +111,5 @@ environments:
   production:
     dataSource:
       dbCreate: update
-      url: jdbc:postgresql://mpdb.idmed.csaude.org.mz:50420/idmed_maputo
+      url: jdbc:postgresql://db:5432/idmed
 

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/episode/EpisodeController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/episode/EpisodeController.groovy
@@ -9,6 +9,7 @@ import mz.org.fgh.sifmoz.backend.clinic.Clinic
 import mz.org.fgh.sifmoz.backend.clinicSector.ClinicSector
 import mz.org.fgh.sifmoz.backend.convertDateUtils.ConvertDateUtils
 import mz.org.fgh.sifmoz.backend.episodeType.EpisodeType
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.patientIdentifier.PatientServiceIdentifier
 import mz.org.fgh.sifmoz.backend.patientVisit.PatientVisit
 import mz.org.fgh.sifmoz.backend.startStopReason.StartStopReason
@@ -49,6 +50,7 @@ class EpisodeController extends RestfulController {
     def save() {
 
         Episode episode = new Episode()
+
         def objectJSON = request.JSON
         episode = objectJSON as Episode
 
@@ -66,16 +68,17 @@ class EpisodeController extends RestfulController {
         }
 
         try {
+
+            configEpisodeOrigin(episode)
             episodeService.save(episode)
             if (episode.startStopReason.code.equalsIgnoreCase(StartStopReason.TRANSFERIDO_PARA) ||
                     episode.startStopReason.code.equalsIgnoreCase(StartStopReason.OBITO)) {
-                        closePatientServiceIdentifierOfPatientWithTrasnferenceOrObitEpisode(episode)
-                    }
+                closePatientServiceIdentifierOfPatientWithTrasnferenceOrObitEpisode(episode)
+            }
             if (episode.startStopReason.code.equalsIgnoreCase("TRANSFERIDO_PARA") ||
                     episode.startStopReason.code.equalsIgnoreCase("REFERIDO_DC") ||
                     episode.startStopReason.code.equalsIgnoreCase("REFERIDO_PARA") ||
-                    episode.startStopReason.code.equalsIgnoreCase("VOLTOU_REFERENCIA"))
-            {
+                    episode.startStopReason.code.equalsIgnoreCase("VOLTOU_REFERENCIA")) {
                 patientTransReferenceCloseMobileEpisode(episode).save()
                 createCloseEpisodeForOtherPatientIdentifiersWhenPatientReferred(episode)
             }
@@ -96,6 +99,8 @@ class EpisodeController extends RestfulController {
     @Transactional
     def update() {
         def objectJSON = request.JSON
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+
         def auxEpisode = (parseTo(objectJSON.toString()) as Map) as Episode
         Episode episode = Episode.get(objectJSON.id)
         bindData(episode, auxEpisode, [exclude: ['id']])
@@ -112,6 +117,7 @@ class EpisodeController extends RestfulController {
         }
 
         try {
+            configEpisodeOrigin(episode)
             episodeService.save(episode)
         } catch (ValidationException e) {
             respond episode.errors
@@ -123,7 +129,7 @@ class EpisodeController extends RestfulController {
 
     @Transactional
     def delete(String id) {
-        List<String> startStopReasonList = ['REFERIDO_PARA','REFERIDO_SECTOR_CLINICO' , 'REFERIDO_DC'].asList()
+        List<String> startStopReasonList = ['REFERIDO_PARA', 'REFERIDO_SECTOR_CLINICO', 'REFERIDO_DC'].asList()
 
         if (id == null || episodeService.delete(id) == null) {
             render status: NOT_FOUND
@@ -132,9 +138,8 @@ class EpisodeController extends RestfulController {
 
         Episode episode = Episode.findById(id)
 
-
-       Episode episodeReferred = Episode.findByEpisodeDateBetweenAndIdNotEqualAndPatientServiceIdentifier(
-               ConvertDateUtils.getDateAtStartOfDay(episode.episodeDate),ConvertDateUtils.getDateAtEndOfDay(episode.episodeDate) , episode.id, episode.patientServiceIdentifier)
+        Episode episodeReferred = Episode.findByEpisodeDateBetweenAndIdNotEqualAndPatientServiceIdentifier(
+                ConvertDateUtils.getDateAtStartOfDay(episode.episodeDate), ConvertDateUtils.getDateAtEndOfDay(episode.episodeDate), episode.id, episode.patientServiceIdentifier)
 
         if (episodeReferred !== null && startStopReasonList.contains(episodeReferred.startStopReason.getCode())) {
             episodeService.delete(episodeReferred.id)
@@ -147,22 +152,15 @@ class EpisodeController extends RestfulController {
     }
 
     def getByIdentifierId(String identifierId, int offset, int max) {
-        // respond episodeService.getAllByIndentifier(identifierId, offset, max)
         render JSONSerializer.setObjectListJsonResponse(episodeService.getAllByIndentifier(identifierId, offset, max)) as JSON
     }
 
 
     def getLastWithVisitByIndentifier(String identifierId, String cliniId) {
-        // respond episodeService.getAllByIndentifier(identifierId, offset, max)
-        //JSON.registerObjectMarshaller(DomainClassMarshaller)
-        //render episodeService.getLastWithVisitByIndentifier(PatientServiceIdentifier.findById(identifierId), Clinic.findById(cliniId))
         render JSONSerializer.setJsonObjectResponse(episodeService.getLastWithVisitByIndentifier(PatientServiceIdentifier.findById(identifierId), Clinic.findById(cliniId))) as JSON
     }
 
     def getLastWithVisitByClinicSectors(String clinicSectorId) {
-        // respond episodeService.getAllByIndentifier(identifierId, offset, max)
-        //JSON.registerObjectMarshaller(DomainClassMarshaller)
-        //render episodeService.getLastWithVisitByIndentifier(PatientServiceIdentifier.findById(identifierId), Clinic.findById(cliniId))
         render JSONSerializer.setObjectListJsonResponse(episodeService.getLastWithVisitByClinicAndClinicSector(ClinicSector.findById(clinicSectorId))) as JSON
     }
 
@@ -200,11 +198,10 @@ class EpisodeController extends RestfulController {
         return transReference
     }
 
-    public closePatientServiceIdentifierOfPatientWithTrasnferenceOrObitEpisode (Episode episode) {
-       def patientServiceIdentifiers =  PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
+    public closePatientServiceIdentifierOfPatientWithTrasnferenceOrObitEpisode(Episode episode) {
+        def patientServiceIdentifiers = PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
 
-        patientServiceIdentifiers.each {item ->
-           // def lastIntialEpisode = episodeService.getLastInitialEpisodeByIdentifier(item.id)
+        patientServiceIdentifiers.each { item ->
             if (item.id == episode.patientServiceIdentifier.id) {
                 item.endDate = episode.episodeDate
                 item.state = 'Inactivo'
@@ -223,6 +220,7 @@ class EpisodeController extends RestfulController {
                 episodeService.save(closureEpisode)
                 item.endDate = episode.episodeDate
                 item.state = 'Inactivo'
+                item.origin = episode.origin
                 item.save(flush: true)
             }
 
@@ -235,27 +233,29 @@ class EpisodeController extends RestfulController {
         render JSONSerializer.setObjectListJsonResponse(Episode.findAllByIdInList(ids)) as JSON
     }
 
-    public createCloseEpisodeForOtherPatientIdentifiersWhenPatientReferred (Episode episode) {
+    public createCloseEpisodeForOtherPatientIdentifiersWhenPatientReferred(Episode episode) {
 
-         def patientServiceIdentifiers =  PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
-         patientServiceIdentifiers.each { item ->
-             if (episode.patientServiceIdentifier.id != item.id) {
-                 Episode closureEpisode = new Episode()
-                 closureEpisode.episodeDate = episode.episodeDate
-                 closureEpisode.episodeType = EpisodeType.findByCode('FIM')
-                 closureEpisode.patientServiceIdentifier = item
-                 closureEpisode.clinic = item.clinic
-                 closureEpisode.clinicSector = episode.clinicSector
-                 closureEpisode.creationDate = new Date()
-                 closureEpisode.notes = 'Fechado Devido ao' + episode.startStopReason.code
-                 closureEpisode.startStopReason = episode.startStopReason
-                 closureEpisode.beforeInsert()
-                 episodeService.save(closureEpisode)
-             }
-         }
+        def patientServiceIdentifiers = PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
+        patientServiceIdentifiers.each { item ->
+            if (episode.patientServiceIdentifier.id != item.id) {
+                Episode closureEpisode = new Episode()
+                closureEpisode.episodeDate = episode.episodeDate
+                closureEpisode.episodeType = EpisodeType.findByCode('FIM')
+                closureEpisode.patientServiceIdentifier = item
+                closureEpisode.clinic = item.clinic
+                closureEpisode.clinicSector = episode.clinicSector
+                closureEpisode.creationDate = new Date()
+                closureEpisode.notes = 'Fechado Devido ao' + episode.startStopReason.code
+                closureEpisode.startStopReason = episode.startStopReason
+                closureEpisode.origin = episode.origin
+                closureEpisode.beforeInsert()
+                episodeService.save(closureEpisode)
+            }
+        }
     }
-    private createStartEpisodeOnSectorAfterReferingToSector (Episode episode) {
-        def patientServiceIdentifiers =  PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
+
+    private createStartEpisodeOnSectorAfterReferingToSector(Episode episode) {
+        def patientServiceIdentifiers = PatientServiceIdentifier.findAllByPatient(episode.patientServiceIdentifier.patient)
         patientServiceIdentifiers.each { item ->
             Episode openingEpisode = new Episode()
             openingEpisode.episodeDate = DateUtils.addMinutes(episode.episodeDate, 1)
@@ -266,8 +266,18 @@ class EpisodeController extends RestfulController {
             openingEpisode.creationDate = new Date()
             openingEpisode.notes = 'Aberto Devido ao' + episode.startStopReason.code
             openingEpisode.startStopReason = StartStopReason.findByCode('MANUNTENCAO')
+            openingEpisode.origin = episode.origin
             openingEpisode.beforeInsert()
             episodeService.save(openingEpisode)
         }
+    }
+
+    private static Episode configEpisodeOrigin(Episode episode) {
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if (systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")) {
+            episode.origin = systemConfigs.description
+        }
+
+        return episode
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/packagedDrug/PackagedDrugController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/packagedDrug/PackagedDrugController.groovy
@@ -3,6 +3,8 @@ package mz.org.fgh.sifmoz.backend.packagedDrug
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.episode.Episode
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -52,6 +54,7 @@ class PackagedDrugController extends RestfulController{
         }
 
         try {
+            configPackagedDrugOrigin(packagedDrug)
             packagedDrugService.save(packagedDrug)
         } catch (ValidationException e) {
             respond packagedDrug.errors
@@ -74,6 +77,7 @@ class PackagedDrugController extends RestfulController{
         }
 
         try {
+            configPackagedDrugOrigin(packagedDrug)
             packagedDrugService.save(packagedDrug)
         } catch (ValidationException e) {
             respond packagedDrug.errors
@@ -95,5 +99,14 @@ class PackagedDrugController extends RestfulController{
 
     def getAllByPackId(String packId) {
         respond packagedDrugService.getAllByPackId(packId)
+    }
+
+    private static PackagedDrug configPackagedDrugOrigin(PackagedDrug packagedDrug){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            packagedDrug.origin = systemConfigs.description
+        }
+
+        return packagedDrug
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/packaging/PackController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/packaging/PackController.groovy
@@ -5,6 +5,7 @@ import grails.rest.RestfulController
 import grails.validation.ValidationException
 import mz.org.fgh.sifmoz.backend.clinic.Clinic
 import mz.org.fgh.sifmoz.backend.episode.Episode
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.packagedDrug.PackagedDrugService
 import mz.org.fgh.sifmoz.backend.packagedDrug.PackagedDrugStock
 import mz.org.fgh.sifmoz.backend.packagedDrug.PackagedDrugStockService
@@ -80,6 +81,7 @@ class PackController extends RestfulController {
         }
 
         try {
+            configPackOrigin(pack)
             packService.save(pack)
         } catch (ValidationException e) {
             respond pack.errors
@@ -102,6 +104,7 @@ class PackController extends RestfulController {
         }
 
         try {
+
             for (PackagedDrug packagedDrug : pack.packagedDrugs) {
                 List<PackagedDrugStock> packagedDrugStocks = PackagedDrugStock.findAllByPackagedDrug(packagedDrug)
                 for (PackagedDrugStock packagedDrugStock : packagedDrugStocks) {
@@ -112,6 +115,7 @@ class PackController extends RestfulController {
                 }
                 packagedDrug.delete()
             }
+            configPackOrigin(pack)
             packService.save(pack)
         } catch (ValidationException e) {
             respond pack.errors
@@ -203,6 +207,15 @@ class PackController extends RestfulController {
         def objectJSON = request.JSON
         List<String> ids = objectJSON
         render JSONSerializer.setObjectListJsonResponse(Pack.findAllByIdInList(ids)) as JSON
+    }
+
+    private static Pack configPackOrigin(Pack pack){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            pack.origin = systemConfigs.description
+        }
+
+        return pack
     }
 
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/patientVisitDetails/PatientVisitDetailsController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/patientVisitDetails/PatientVisitDetailsController.groovy
@@ -5,6 +5,7 @@ import grails.rest.RestfulController
 import grails.validation.ValidationException
 import mz.org.fgh.sifmoz.backend.clinicSector.ClinicSector
 import mz.org.fgh.sifmoz.backend.episode.Episode
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.openmrsErrorLog.OpenmrsErrorLog
 import mz.org.fgh.sifmoz.backend.packagedDrug.PackagedDrug
 import mz.org.fgh.sifmoz.backend.packagedDrug.PackagedDrugStock
@@ -75,6 +76,7 @@ class PatientVisitDetailsController extends RestfulController {
         }
 
         try {
+            configPatientVisitDetailsOrigin(patientVisitDetails)
             determinePrescriptionPatientType(patientVisitDetails)
             patientVisitDetailsService.save(patientVisitDetails)
         } catch (ValidationException e) {
@@ -98,6 +100,7 @@ class PatientVisitDetailsController extends RestfulController {
         }
 
         try {
+            configPatientVisitDetailsOrigin(patientVisitDetails)
             patientVisitDetailsService.save(patientVisitDetails)
         } catch (ValidationException e) {
             respond patientVisitDetails.errors
@@ -256,5 +259,14 @@ class PatientVisitDetailsController extends RestfulController {
         def result = patientVisitDetailsService.getLastAllByListPatientId(ids)
 
         render JSONSerializer.setObjectListJsonResponse(result) as JSON
+    }
+
+    private static PatientVisitDetails configPatientVisitDetailsOrigin(PatientVisitDetails patientVisitDetails){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            patientVisitDetails.origin = systemConfigs.description
+        }
+
+        return patientVisitDetails
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescription/PrescriptionController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescription/PrescriptionController.groovy
@@ -6,6 +6,7 @@ import grails.rest.RestfulController
 import grails.validation.ValidationException
 import mz.org.fgh.sifmoz.backend.doctor.DoctorService
 import mz.org.fgh.sifmoz.backend.episode.Episode
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.packaging.Pack
 import mz.org.fgh.sifmoz.backend.patient.Patient
 import mz.org.fgh.sifmoz.backend.patientIdentifier.PatientServiceIdentifier
@@ -74,6 +75,7 @@ class PrescriptionController extends RestfulController{
             if (!Utilities.stringHasValue(prescription.id)) {
                 prescription.generateNextSeq()
             }
+            configPrescriptionOrigin(prescription)
             prescriptionService.save(prescription)
         } catch (ValidationException e) {
             respond prescription.errors
@@ -96,6 +98,7 @@ class PrescriptionController extends RestfulController{
         }
 
         try {
+            configPrescriptionOrigin(prescription)
             prescriptionService.save(prescription)
         } catch (ValidationException e) {
             respond prescription.errors
@@ -179,5 +182,14 @@ class PrescriptionController extends RestfulController{
         def objectJSON = request.JSON
         List<String> ids = objectJSON
         render JSONSerializer.setObjectListJsonResponse(Prescription.findAllByIdInList(ids)) as JSON
+    }
+
+    private static Prescription configPrescriptionOrigin(Prescription prescription){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            prescription.origin = systemConfigs.description
+        }
+
+        return prescription
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescriptionDetail/PrescriptionDetailController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescriptionDetail/PrescriptionDetailController.groovy
@@ -3,6 +3,8 @@ package mz.org.fgh.sifmoz.backend.prescriptionDetail
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
+import mz.org.fgh.sifmoz.backend.prescription.Prescription
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +55,7 @@ class PrescriptionDetailController extends RestfulController{
         }
 
         try {
+            configPrescriptionDetailOrigin(prescriptionDetail)
             prescriptionDetailService.save(prescriptionDetail)
         } catch (ValidationException e) {
             respond prescriptionDetail.errors
@@ -75,6 +78,7 @@ class PrescriptionDetailController extends RestfulController{
         }
 
         try {
+            configPrescriptionDetailOrigin(prescriptionDetail)
             prescriptionDetailService.save(prescriptionDetail)
         } catch (ValidationException e) {
             respond prescriptionDetail.errors
@@ -96,5 +100,14 @@ class PrescriptionDetailController extends RestfulController{
 
     def getAllByPrescriptionId(String prescriptionId) {
         respond prescriptionDetailService.getAllByPrescriptionId(prescriptionId)
+    }
+
+    private static PrescriptionDetail configPrescriptionDetailOrigin(PrescriptionDetail prescriptionDetail){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            prescriptionDetail.origin = systemConfigs.description
+        }
+
+        return prescriptionDetail
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescriptionDrug/PrescribedDrugController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/prescriptionDrug/PrescribedDrugController.groovy
@@ -3,6 +3,8 @@ package mz.org.fgh.sifmoz.backend.prescriptionDrug
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
+import mz.org.fgh.sifmoz.backend.prescriptionDetail.PrescriptionDetail
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +55,7 @@ class PrescribedDrugController extends RestfulController{
         }
 
         try {
+            configPrescribedDrugOrigin(prescribedDrug)
             prescribedDrugService.save(prescribedDrug)
         } catch (ValidationException e) {
             respond prescribedDrug.errors
@@ -75,6 +78,7 @@ class PrescribedDrugController extends RestfulController{
         }
 
         try {
+            configPrescribedDrugOrigin(prescribedDrug)
             prescribedDrugService.save(prescribedDrug)
         } catch (ValidationException e) {
             respond prescribedDrug.errors
@@ -96,5 +100,14 @@ class PrescribedDrugController extends RestfulController{
 
     def getAllByPrescriptionId(String prescriptionId) {
         respond prescribedDrugService.getAllByPrescriptionId(prescriptionId)
+    }
+
+    private static PrescribedDrug configPrescribedDrugOrigin(PrescribedDrug prescribedDrug){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            prescribedDrug.origin = systemConfigs.description
+        }
+
+        return prescribedDrug
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/AdherenceScreeningController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/AdherenceScreeningController.groovy
@@ -3,6 +3,8 @@ package mz.org.fgh.sifmoz.backend.screening
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
+import mz.org.fgh.sifmoz.backend.prescriptionDrug.PrescribedDrug
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +55,7 @@ class AdherenceScreeningController extends RestfulController{
         }
 
         try {
+            configAdherenceScreeningOrigin(adherenceScreening)
             adherenceScreeningService.save(adherenceScreening)
         } catch (ValidationException e) {
             respond adherenceScreening.errors
@@ -75,6 +78,7 @@ class AdherenceScreeningController extends RestfulController{
         }
 
         try {
+            configAdherenceScreeningOrigin(adherenceScreening)
             adherenceScreeningService.save(adherenceScreening)
         } catch (ValidationException e) {
             respond adherenceScreening.errors
@@ -92,5 +96,14 @@ class AdherenceScreeningController extends RestfulController{
         }
 
         render status: NO_CONTENT
+    }
+
+    private static AdherenceScreening configAdherenceScreeningOrigin(AdherenceScreening adherenceScreening){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            adherenceScreening.origin = systemConfigs.description
+        }
+
+        return adherenceScreening
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/PregnancyScreeningController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/PregnancyScreeningController.groovy
@@ -3,6 +3,7 @@ package mz.org.fgh.sifmoz.backend.screening
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.patientVisit.PatientVisit
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
@@ -55,6 +56,7 @@ class PregnancyScreeningController extends RestfulController{
         }
 
         try {
+            configPregnancyScreeningOrigin(pregnancyScreening)
             pregnancyScreeningService.save(pregnancyScreening)
         } catch (ValidationException e) {
             respond pregnancyScreening.errors
@@ -77,6 +79,7 @@ class PregnancyScreeningController extends RestfulController{
         }
 
         try {
+            configPregnancyScreeningOrigin(pregnancyScreening)
             pregnancyScreeningService.save(pregnancyScreening)
         } catch (ValidationException e) {
             respond pregnancyScreening.errors
@@ -98,5 +101,14 @@ class PregnancyScreeningController extends RestfulController{
 
     def getAllByPatientVisit(String patientVisitId, int offset, int max) {
         render JSONSerializer.setObjectListJsonResponse(PregnancyScreening.findAllByVisit(PatientVisit.findById(patientVisitId))) as JSON
+    }
+
+    private static PregnancyScreening configPregnancyScreeningOrigin(PregnancyScreening pregnancyScreening){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            pregnancyScreening.origin = systemConfigs.description
+        }
+
+        return pregnancyScreening
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/RAMScreeningController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/RAMScreeningController.groovy
@@ -3,6 +3,7 @@ package mz.org.fgh.sifmoz.backend.screening
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +54,7 @@ class RAMScreeningController extends RestfulController{
         }
 
         try {
+            configRAMScreeningOrigin(rAMScreening)
             RAMScreeningService.save(rAMScreening)
         } catch (ValidationException e) {
             respond rAMScreening.errors
@@ -75,6 +77,7 @@ class RAMScreeningController extends RestfulController{
         }
 
         try {
+            configRAMScreeningOrigin(rAMScreening)
             RAMScreeningService.save(rAMScreening)
         } catch (ValidationException e) {
             respond rAMScreening.errors
@@ -92,5 +95,14 @@ class RAMScreeningController extends RestfulController{
         }
 
         render status: NO_CONTENT
+    }
+
+    private static RAMScreening configRAMScreeningOrigin(RAMScreening ramScreening){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            ramScreening.origin = systemConfigs.description
+        }
+
+        return ramScreening
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/TBScreeningController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/TBScreeningController.groovy
@@ -3,6 +3,7 @@ package mz.org.fgh.sifmoz.backend.screening
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +54,7 @@ class TBScreeningController extends RestfulController{
         }
 
         try {
+            configTBScreeningOrigin(tBScreening)
             TBScreeningService.save(tBScreening)
         } catch (ValidationException e) {
             respond tBScreening.errors
@@ -75,6 +77,7 @@ class TBScreeningController extends RestfulController{
         }
 
         try {
+            configTBScreeningOrigin(tBScreening)
             TBScreeningService.save(tBScreening)
         } catch (ValidationException e) {
             respond tBScreening.errors
@@ -92,5 +95,14 @@ class TBScreeningController extends RestfulController{
         }
 
         render status: NO_CONTENT
+    }
+
+    private static TBScreening configTBScreeningOrigin(TBScreening tbScreening){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            tbScreening.origin = systemConfigs.description
+        }
+
+        return tbScreening
     }
 }

--- a/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/VitalSignsScreeningController.groovy
+++ b/grails-app/controllers/mz/org/fgh/sifmoz/backend/screening/VitalSignsScreeningController.groovy
@@ -3,6 +3,7 @@ package mz.org.fgh.sifmoz.backend.screening
 import grails.converters.JSON
 import grails.rest.RestfulController
 import grails.validation.ValidationException
+import mz.org.fgh.sifmoz.backend.healthInformationSystem.SystemConfigs
 import mz.org.fgh.sifmoz.backend.utilities.JSONSerializer
 
 import static org.springframework.http.HttpStatus.CREATED
@@ -53,6 +54,7 @@ class VitalSignsScreeningController extends RestfulController{
         }
 
         try {
+            configVitalSignsScreeningOrigin(vitalSignsScreening)
             vitalSignsScreeningService.save(vitalSignsScreening)
         } catch (ValidationException e) {
             respond vitalSignsScreening.errors
@@ -75,6 +77,7 @@ class VitalSignsScreeningController extends RestfulController{
         }
 
         try {
+            configVitalSignsScreeningOrigin(vitalSignsScreening)
             vitalSignsScreeningService.save(vitalSignsScreening)
         } catch (ValidationException e) {
             respond vitalSignsScreening.errors
@@ -93,4 +96,14 @@ class VitalSignsScreeningController extends RestfulController{
 
         render status: NO_CONTENT
     }
+
+    private static VitalSignsScreening configVitalSignsScreeningOrigin(VitalSignsScreening vitalSignsScreening){
+        SystemConfigs systemConfigs = SystemConfigs.findByKey("INSTALATION_TYPE")
+        if(systemConfigs && systemConfigs.value.equalsIgnoreCase("LOCAL")){
+            vitalSignsScreening.origin = systemConfigs.description
+        }
+
+        return vitalSignsScreening
+    }
+
 }

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/episode/Episode.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/episode/Episode.groovy
@@ -1,17 +1,13 @@
 package mz.org.fgh.sifmoz.backend.episode
 
-import com.fasterxml.jackson.annotation.JsonBackReference
+
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonManagedReference
 import mz.org.fgh.sifmoz.backend.base.BaseEntity
 import mz.org.fgh.sifmoz.backend.clinic.Clinic
-import mz.org.fgh.sifmoz.backend.clinicSector.ClinicSector
 import mz.org.fgh.sifmoz.backend.episodeType.EpisodeType
 import mz.org.fgh.sifmoz.backend.patientIdentifier.PatientServiceIdentifier
-import mz.org.fgh.sifmoz.backend.patientVisitDetails.PatientVisitDetails
-import mz.org.fgh.sifmoz.backend.prescription.Prescription
 import mz.org.fgh.sifmoz.backend.protection.Menu
-import mz.org.fgh.sifmoz.backend.service.ClinicalService
 import mz.org.fgh.sifmoz.backend.startStopReason.StartStopReason
 
 class Episode extends BaseEntity {
@@ -26,16 +22,12 @@ class Episode extends BaseEntity {
     Clinic clinicSector
     @JsonIgnore
     Clinic clinic
-
     @JsonIgnore
     Clinic referralClinic
-
     boolean isAbandonmentDC
+    String origin
 
     static belongsTo = [patientServiceIdentifier: PatientServiceIdentifier]
-
-//    @JsonBackReference
-//    static hasMany = [patientVisitDetails: PatientVisitDetails]
 
     static mapping = {
         id generator: "assigned"
@@ -49,6 +41,7 @@ class Episode extends BaseEntity {
             return episodeDate <= new Date()
         })
         referralClinic nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {
@@ -59,22 +52,6 @@ class Episode extends BaseEntity {
             clinic = Clinic.findByMainClinic(true)
         }
     }
-
-//    @Override
-//    public String toString() {
-//        return "Episode{" +
-//                "patientVisitDetails=" + patientVisitDetails +
-//                ", patientServiceIdentifier=" + patientServiceIdentifier +
-//                ", id='" + id + '\'' +
-//                ", episodeDate=" + episodeDate +
-//                ", creationDate=" + creationDate +
-//                ", startStopReason=" + startStopReason +
-//                ", notes='" + notes + '\'' +
-//                ", episodeType=" + episodeType +
-//                ", clinicSector=" + clinicSector +
-//                ", clinic=" + clinic +
-//                '}';
-//    }
 
     @Override
     List<Menu> hasMenus() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/packagedDrug/PackagedDrug.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/packagedDrug/PackagedDrug.groovy
@@ -23,6 +23,7 @@ class PackagedDrug extends BaseEntity {
     Pack pack
     int quantityRemain
     Clinic clinic
+    String origin
     static belongsTo = [Pack]
 
     static hasMany = [packagedDrugStocks: PackagedDrugStock]
@@ -39,6 +40,7 @@ class PackagedDrug extends BaseEntity {
         nextPickUpDate nullable: true
         creationDate nullable: true
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/packaging/Pack.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/packaging/Pack.groovy
@@ -29,6 +29,8 @@ class Pack extends BaseEntity {
     Date creationDate = new Date()
     boolean isreferral = false
     boolean isreferalsynced = false
+    String origin
+
     static hasMany = [packagedDrugs: PackagedDrug]
     static mapping = {
         id generator: "assigned"
@@ -50,6 +52,7 @@ class Pack extends BaseEntity {
         groupPack nullable: true
         reasonForPackageReturn(nullable: true,maxSize: 500)
         creationDate nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/patient/Patient.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/patient/Patient.groovy
@@ -41,9 +41,10 @@ class Patient extends BaseEntity implements Auditable{
     char hisSyncStatus
     String hisProvider
     Long matchId
-
     Clinic clinic
     Date creationDate = new Date()
+    String origin
+
     static belongsTo = [Clinic]
 
     static auditable = true
@@ -81,6 +82,7 @@ class Patient extends BaseEntity implements Auditable{
         creationDate nullable: true
         hisSyncStatus nullable: true
         hisProvider nullable: true
+        origin nullable: true
         matchId nullable: false, unique: true
     }
 

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/patientIdentifier/PatientServiceIdentifier.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/patientIdentifier/PatientServiceIdentifier.groovy
@@ -20,6 +20,7 @@ class PatientServiceIdentifier extends BaseEntity {
     IdentifierType identifierType
     ClinicalService service
     Clinic clinic
+    String origin
 
     static belongsTo = [patient: Patient]
 
@@ -37,29 +38,12 @@ class PatientServiceIdentifier extends BaseEntity {
         })
         endDate nullable: true
         reopenDate nullable: true
+        origin nullable: true
     }
 
     boolean hasEpisodes () {
         return Utilities.listHasElements(this.episodes as ArrayList<?>)
     }
-
-//    @Override
-//    public String toString() {
-//        return "PatientServiceIdentifier{" +
-//                "patient=" + patient +
-//                ", episodes=" + episodes +
-//                ", id='" + id + '\'' +
-//                ", startDate=" + startDate +
-//                ", endDate=" + endDate +
-//                ", reopenDate=" + reopenDate +
-//                ", value='" + value + '\'' +
-//                ", state='" + state + '\'' +
-//                ", prefered=" + prefered +
-//                ", identifierType=" + identifierType +
-//                ", service=" + service +
-//                ", clinic=" + clinic +
-//                '}';
-//    }
 
     def beforeInsert() {
         if (!id) {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/patientVisit/PatientVisit.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/patientVisit/PatientVisit.groovy
@@ -21,6 +21,7 @@ class PatientVisit extends BaseEntity {
     @JsonIgnore
     Clinic clinic
     Date creationDate = new Date()
+    String origin
 
     @JsonIgnore
     Patient patient
@@ -37,6 +38,7 @@ class PatientVisit extends BaseEntity {
 
     static constraints = {
         creationDate nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/patientVisitDetails/PatientVisitDetails.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/patientVisitDetails/PatientVisitDetails.groovy
@@ -20,6 +20,7 @@ class PatientVisitDetails extends BaseEntity {
     Pack pack
     PatientVisit patientVisit
     Date creationDate = new Date()
+    String origin
 
     static belongsTo = [PatientVisit]
 
@@ -30,6 +31,7 @@ class PatientVisitDetails extends BaseEntity {
     static constraints = {
         pack nullable: false
         creationDate nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/prescription/Prescription.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/prescription/Prescription.groovy
@@ -41,6 +41,8 @@ class Prescription extends BaseEntity{
     String photoName
     String photoContentType
     Date creationDate = new Date()
+    String origin
+
     static hasMany = [prescribedDrugs: PrescribedDrug, prescriptionDetails: PrescriptionDetail]
 
     static mapping = {
@@ -60,6 +62,7 @@ class Prescription extends BaseEntity{
         photoContentType nullable: true, blank: true
         patientStatus nullable: true, blank: true
         creationDate nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/prescriptionDetail/PrescriptionDetail.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/prescriptionDetail/PrescriptionDetail.groovy
@@ -20,6 +20,7 @@ class PrescriptionDetail extends BaseEntity {
     SpetialPrescriptionMotive spetialPrescriptionMotive
     Date creationDate = new Date()
     Clinic clinic
+    String origin
     static belongsTo = [Prescription]
 
     static mapping = {
@@ -34,6 +35,7 @@ class PrescriptionDetail extends BaseEntity {
         therapeuticLine nullable: true
         spetialPrescriptionMotive nullable: true
         creationDate nullable: true
+        origin nullable: true
         clinic blank: true, nullable: true
     }
 

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/prescriptionDrug/PrescribedDrug.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/prescriptionDrug/PrescribedDrug.groovy
@@ -21,6 +21,7 @@ class PrescribedDrug extends BaseEntity {
     @JsonBackReference
     Prescription prescription
     Clinic clinic
+    String origin
     static belongsTo = [Prescription]
 
     static mapping = {
@@ -30,6 +31,7 @@ class PrescribedDrug extends BaseEntity {
     static constraints = {
         timesPerDay(min: 1)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/AdherenceScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/AdherenceScreening.groovy
@@ -18,6 +18,7 @@ class AdherenceScreening extends BaseEntity {
     @JsonBackReference
     PatientVisit visit
     Clinic clinic
+    String origin
 
     static belongsTo = [PatientVisit]
     static mapping = {
@@ -30,6 +31,7 @@ class AdherenceScreening extends BaseEntity {
         daysWithoutMedicine(nullable: true,blank: true)
         lateDays(nullable: true, blank: true)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/PregnancyScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/PregnancyScreening.groovy
@@ -15,7 +15,7 @@ class PregnancyScreening extends BaseEntity {
     @JsonBackReference
     PatientVisit visit
     Clinic clinic
-
+    String origin
     static belongsTo = [PatientVisit]
 
     static mapping = {
@@ -26,6 +26,7 @@ class PregnancyScreening extends BaseEntity {
     static constraints = {
         lastMenstruation(nullable: true, blank: true)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/RAMScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/RAMScreening.groovy
@@ -15,6 +15,8 @@ class RAMScreening extends BaseEntity {
     @JsonBackReference
     PatientVisit visit
     Clinic clinic
+    String origin
+
     static belongsTo = [PatientVisit]
 
     static mapping = {
@@ -25,6 +27,7 @@ class RAMScreening extends BaseEntity {
     static constraints = {
         adverseReaction(nullable: true, blank: true)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/TBScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/TBScreening.groovy
@@ -23,6 +23,7 @@ class TBScreening extends BaseEntity {
     @JsonBackReference
     PatientVisit visit
     Clinic clinic
+    String origin
 
     static belongsTo = [PatientVisit]
 
@@ -35,6 +36,7 @@ class TBScreening extends BaseEntity {
         startTreatmentDate(nullable: true, blank: true)
         visit(nullable: true, blank: true)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {

--- a/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/VitalSignsScreening.groovy
+++ b/grails-app/domain/mz/org/fgh/sifmoz/backend/screening/VitalSignsScreening.groovy
@@ -9,15 +9,16 @@ import mz.org.fgh.sifmoz.backend.protection.Menu
 
 class VitalSignsScreening extends BaseEntity {
     String id
-    int distort;
-    String imc;
-    double weight;
-    int systole;
-    double height;
+    int distort
+    String imc
+    double weight
+    int systole
+    double height
 
     @JsonBackReference
     PatientVisit visit
     Clinic clinic
+    String origin
 
     static belongsTo = [PatientVisit]
     static mapping = {
@@ -28,6 +29,7 @@ class VitalSignsScreening extends BaseEntity {
     static constraints = {
         distort (nullable: false)
         clinic blank: true, nullable: true
+        origin nullable: true
     }
 
     def beforeInsert() {
@@ -35,17 +37,6 @@ class VitalSignsScreening extends BaseEntity {
             id = UUID.randomUUID()
             clinic = Clinic.findWhere(mainClinic: true)
         }
-    }
-
-    @Override
-    public String toString() {
-        return "VitalSignsScreening{" +
-                "distort=" + distort +
-                ", imc='" + imc + '\'' +
-                ", weight=" + weight +
-                ", systole=" + systole +
-                ", height=" + height +
-                '}';
     }
 
     @Override


### PR DESCRIPTION
Ensured 'origin' field is set based on system configuration for various entities including prescribed drugs, patient visit details, prescription details, and others. This change integrates the system-configured installation type description to the origin field of these entities, improving traceability and data consistency.